### PR TITLE
hotfix - add google images to CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Henrique Bonfim</title>
   <meta name="author" content="Henrique Bonfim" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; connect-src 'self' https://*.google.com https://*.doubleclick.net; script-src 'self' https://www.googletagmanager.com 'nonce-1234567890' 'sha256-oNrZ7nOOn8m02x5nI0goaMfMi6zPIAZBZ9yZF6dTHrI='; img-src 'self' https://avatars3.githubusercontent.com; style-src 'self' 'unsafe-inline';">
+    content="default-src 'self'; connect-src 'self' https://*.google.com https://*.doubleclick.net; script-src 'self' https://www.googletagmanager.com 'nonce-1234567890' 'sha256-oNrZ7nOOn8m02x5nI0goaMfMi6zPIAZBZ9yZF6dTHrI='; img-src 'self' https://avatars3.githubusercontent.com https://*.google.com; style-src 'self' 'unsafe-inline';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="My simple website with full CI/CD">
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
- fix this error:
![image](https://github.com/hpbonfim/website/assets/40275173/278183c6-f95a-464f-856d-3bede78b964d)
